### PR TITLE
fix  miss MAIL FROM

### DIFF
--- a/server/src/Config/email.js
+++ b/server/src/Config/email.js
@@ -38,6 +38,9 @@ let transport = nodemailer.createTransport({
 });
 
 export const email = new Email({
+  message: {
+    from: user
+  },
   send: true,
   transport,
   preview: true, // to preview emails in your own browser


### PR DESCRIPTION
550 From header is missing, header is not RFC 5322 compliant
some error when sendmail user nodemail 

Error: Mail command failed: 550 From header is missing, header is not RFC 5322 compliant
    at SMTPConnection._formatError (C:\Users\jiang\SAAS-Starter-Kit-Pro\server\node_modules\nodemailer\lib\smtp-connection\index.js:784:19)
    at SMTPConnection._actionMAIL (C:\Users\jiang\SAAS-Starter-Kit-Pro\server\node_modules\nodemailer\lib\smtp-connection\index.js:1566:34)
    at SMTPConnection.<anonymous> (C:\Users\jiang\SAAS-Starter-Kit-Pro\server\node_modules\nodemailer\lib\smtp-connection\index.js:1041:18)
    at SMTPConnection._processResponse (C:\Users\jiang\SAAS-Starter-Kit-Pro\server\node_modules\nodemailer\lib\smtp-connection\index.js:947:20)
    at SMTPConnection._onData (C:\Users\jiang\SAAS-Starter-Kit-Pro\server\node_modules\nodemailer\lib\smtp-connection\index.js:749:14)
    at TLSSocket.SMTPConnection._onSocketData (C:\Users\jiang\SAAS-Starter-Kit-Pro\server\node_modules\nodemailer\lib\smtp-connection\index.js:189:44)
    at TLSSocket.emit (node:events:390:28)
    at TLSSocket.emit (node:domain:475:12)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at TLSSocket.Readable.push (node:internal/streams/readable:228:10)
    at TLSWrap.onStreamRead (node:internal/stream_base_commons:199:23) {
  code: 'EENVELOPE',
  response: '550 From header is missing, header is not RFC 5322 compliant',
  responseCode: 550,
  command: 'MAIL FROM'
}